### PR TITLE
Breakup Evaluators for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Agents
 
-Some rendering code copied from https://github.com/rustwasm/wasm_game_of_life/.
-
 ## Examples
 
 ```
@@ -33,3 +31,7 @@ agent blue_agent:
         set b = 5
     exit:
 ```
+
+## Referenced Links and Credits
+
+- Frontend and rendering code heavily referenced examples from https://github.com/rustwasm/wasm_game_of_life/

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -30,31 +30,54 @@ impl Agent {
     }
 }
 
+/// All valid Command variants that an Agent can perform.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Command {
+    /// Sets a variable identified by the string to the primitive evaluated to by
+    /// the associated Expression.
     SetVariable(String, Expression),
+    /// Defines the direction an agent should face.
     Face(Direction),
+    /// Turns by a number of rotations where a positive number represents a
+    /// clockwise rotation and a negavite represents a counter-clockwise
+    /// rotation.
     Turn(i32),
+    /// Move specifies the steps that an agent will move in the direction it is
+    /// facing.
     Move(u32),
+    /// Goto jumps to the enclosed offset in an agents command list.
     Goto(u32),
+    /// Like Goto, JumpTrue jumps to the enclosed offset if the passed conditional
+    /// expression evaluates to true.
     JumpTrue(u32, Expression),
 }
 
+/// Sets a variable identified by the string to the primitive evaluated to by
+/// the associated Expression on an associated agent..
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetVariableCmd(pub String, pub Expression);
 
+/// Defines the direction an agent should face.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FaceCmd(pub Direction);
 
+/// Turns by a number of rotations where a positive number represents a
+/// clockwise rotation and a negavite represents a counter-clockwise
+/// rotation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TurnCmd(pub i32);
 
+/// Move specifies the steps that an agent will move in the direction it is
+/// facing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MoveCmd(pub u32);
 
+/// Goto jumps to the enclosed offset in an agents command list.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GotoCmd(pub u32);
 
+/// Like Goto, JumpTrue jumps to the enclosed offset if the passed conditional
+/// expression evaluates to true.
 #[derive(Debug, Clone, PartialEq)]
 pub struct JumpTrueCmd(pub u32, pub Expression);
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,24 +1,26 @@
+/// A program is composed of zero or more agent scripts.
 #[derive(Debug)]
-pub struct Program {
-    agents: Vec<Agent>,
-}
+pub struct Program(Vec<Agent>);
 
 impl Program {
+    /// initializes a new program from a list of agents
     pub fn new(agents: Vec<Agent>) -> Self {
-        Self { agents }
+        Self(agents)
     }
 
+    /// Returns a borrowed slice of agents.
     pub fn agents(&self) -> &[Agent] {
-        &self.agents
+        &self.0
     }
 }
 
 impl From<Program> for Vec<Agent> {
     fn from(program: Program) -> Self {
-        program.agents
+        program.0
     }
 }
 
+/// An agent is represented by a list of commands.
 #[derive(Debug, PartialEq)]
 pub struct Agent {
     commands: Vec<Command>,
@@ -81,14 +83,23 @@ pub struct GotoCmd(pub u32);
 #[derive(Debug, Clone, PartialEq)]
 pub struct JumpTrueCmd(pub u32, pub Expression);
 
+/// Expresion covers the simple expression operations that can evaluated in
+/// some agent commands.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expression {
+    /// Evaluates to a Literal Primitive. ex. `5`
     Literal(Primitive),
+    /// Evaluates equality on two evaluated expressions. ex.`5 == 5`
     Equals(Box<Expression>, Box<Expression>),
+    /// References a variable. ex `a`
     GetVariable(String),
+    /// Evaluates the sum of two expressions. ex. `5 + 5`
     Add(Box<Expression>, Box<Expression>),
+    /// Evaluates the difference of two expressions. ex. `5 - 5`
     Sub(Box<Expression>, Box<Expression>),
+    /// Evaluates the product of two expressions. ex. `5 * 5`
     Mul(Box<Expression>, Box<Expression>),
+    /// Evaluates the quotient of two expressions. ex. `5 / 5`
     Div(Box<Expression>, Box<Expression>),
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -92,6 +92,7 @@ pub enum Expression {
     Div(Box<Expression>, Box<Expression>),
 }
 
+/// Represents the cardinal directions that an agent can face.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
 pub enum Direction {
@@ -121,6 +122,7 @@ impl From<i32> for Direction {
     }
 }
 
+/// Valid primititive types for the language, currently only integer or boolean.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Primitive {
     Integer(i32),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -50,6 +50,15 @@ pub struct FaceCmd(pub Direction);
 pub struct TurnCmd(pub i32);
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct MoveCmd(pub u32);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GotoCmd(pub u32);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct JumpTrueCmd(pub u32, pub Expression);
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expression {
     Literal(Primitive),
     Equals(Box<Expression>, Box<Expression>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -31,7 +31,6 @@ impl Agent {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-
 pub enum Command {
     SetVariable(String, Expression),
     Face(Direction),
@@ -42,7 +41,15 @@ pub enum Command {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct SetVariableCmd(pub String, pub Expression);
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct FaceCmd(pub Direction);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TurnCmd(pub i32);
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expression {
     Literal(Primitive),
     Equals(Box<Expression>, Box<Expression>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ impl Coordinates {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AgentState {
     vars: HashMap<String, ast::Primitive>,
     commands: Vec<ast::Command>,
@@ -83,6 +83,44 @@ impl AgentState {
             coords: Coordinates(x, y),
             direction,
             color,
+        }
+    }
+
+    pub fn with_commands(mut self, commands: Vec<ast::Command>) -> Self {
+        self.commands = commands;
+        self
+    }
+
+    pub fn with_pc(mut self, pc: u32) -> Self {
+        self.pc = pc;
+        self
+    }
+
+    pub fn with_direction(mut self, direction: ast::Direction) -> Self {
+        self.direction = direction;
+        self
+    }
+
+    pub fn with_color(mut self, color: u32) -> Self {
+        self.color = color;
+        self
+    }
+
+    pub fn with_coordinates(mut self, coordinates: Coordinates) -> Self {
+        self.coords = coordinates;
+        self
+    }
+}
+
+impl Default for AgentState {
+    fn default() -> Self {
+        Self {
+            vars: Default::default(),
+            commands: Default::default(),
+            pc: Default::default(),
+            coords: Coordinates(0, 0),
+            direction: ast::Direction::S,
+            color: Default::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,16 @@ impl AgentState {
     }
 }
 
+impl<M> Evaluate<AgentState> for M
+where
+    AgentState: EvaluateMut<M>,
+{
+    fn evaluate(self, mut state: AgentState) -> AgentState {
+        state.evaluate_mut(self);
+        state
+    }
+}
+
 impl EvaluateMut<ast::Command> for AgentState {
     type Output = Result<Vec<Coordinates>, String>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use ast::{Command, Expression};
 use std::sync::Mutex;
 use wasm_bindgen::prelude::*;
 
+#[cfg(test)]
+mod tests;
+
 /// Provides traits for evaluating a type onto a state, returning the modified
 /// state.
 pub trait Evaluate<T> {
@@ -192,14 +195,14 @@ impl EvaluateMut<ast::MoveCmd> for AgentState {
 /// Updates coordinates to represent a move of n steps in a given direction
 fn move_in_direction(steps: u32, direction: ast::Direction, origin: Coordinates) -> Coordinates {
     match direction {
-        ast::Direction::N => Coordinates(origin.x(), origin.y() + steps),
-        ast::Direction::NE => Coordinates(origin.x() + steps, origin.y() + steps),
+        ast::Direction::N => Coordinates(origin.x(), origin.y() - steps),
+        ast::Direction::NE => Coordinates(origin.x() + steps, origin.y() - steps),
+        ast::Direction::NW => Coordinates(origin.x() - steps, origin.y() - steps),
         ast::Direction::E => Coordinates(origin.x() + steps, origin.y()),
         ast::Direction::SE => Coordinates(origin.x() - steps, origin.y() + steps),
-        ast::Direction::S => Coordinates(origin.x(), origin.y() - steps),
-        ast::Direction::SW => Coordinates(origin.x() - steps, origin.y() - steps),
+        ast::Direction::S => Coordinates(origin.x(), origin.y() + steps),
+        ast::Direction::SW => Coordinates(origin.x() - steps, origin.y() + steps),
         ast::Direction::W => Coordinates(origin.x() - steps, origin.y()),
-        ast::Direction::NW => Coordinates(origin.x() - steps, origin.y() + steps),
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,10 +26,12 @@ pub enum ParseErr {
 }
 
 #[allow(dead_code)]
-pub fn parse(input: &[(usize, char)]) -> Result<ast::Program, ParseErr> {
-    parcel::one_or_more(agent())
+pub fn parse(source: &str) -> Result<ast::Program, ParseErr> {
+    let input: Vec<(usize, char)> = source.chars().enumerate().collect();
+
+    let res = parcel::one_or_more(agent())
         .map(ast::Program::new)
-        .parse(input)
+        .parse(&input)
         .map_err(ParseErr::Unspecified)
         .and_then(|ms| match ms {
             MatchStatus::Match {
@@ -40,7 +42,8 @@ pub fn parse(input: &[(usize, char)]) -> Result<ast::Program, ParseErr> {
             MatchStatus::NoMatch(_) => {
                 Err(ParseErr::Unspecified("not a valid program".to_string()))
             }
-        })
+        });
+    res
 }
 
 fn agent<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Agent> {
@@ -444,8 +447,7 @@ agent blue_agent:
 
     #[test]
     fn should_parse_agent_commands() {
-        let input: Vec<(usize, char)> = TEST_PROGRAM.chars().enumerate().collect();
-        let res = crate::parser::parse(&input);
+        let res = crate::parser::parse(TEST_PROGRAM);
 
         assert_eq!(Ok(2), res.map(|program| program.agents().len()),);
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,14 @@
+use crate::{AgentState, Evaluate};
+
+#[test]
+fn should_generate_expected_new_coordinates_for_move() {
+    let agent_state = AgentState::default().with_commands(vec![crate::ast::Command::Move(5)]);
+
+    assert_eq!(
+        AgentState::default()
+            .with_commands(vec![crate::ast::Command::Move(5)])
+            .with_pc(1)
+            .with_coordinates(crate::Coordinates(0, 5)),
+        crate::ast::Command::Move(5).evaluate(agent_state)
+    )
+}


### PR DESCRIPTION
# Introduction
Small PR to break up the evaluators into distinct types and to add some docstrings for readability.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
