### PR TITLE
Implement Board Boundary Interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 agent red_agent:
-    set color = 255
+    set color = 16711680
     set x = 0
     set y = 0
     set direction = 0

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -54,35 +54,6 @@ pub enum Command {
     JumpTrue(u32, Expression),
 }
 
-/// Sets a variable identified by the string to the primitive evaluated to by
-/// the associated Expression on an associated agent..
-#[derive(Debug, Clone, PartialEq)]
-pub struct SetVariableCmd(pub String, pub Expression);
-
-/// Defines the direction an agent should face.
-#[derive(Debug, Clone, PartialEq)]
-pub struct FaceCmd(pub Direction);
-
-/// Turns by a number of rotations where a positive number represents a
-/// clockwise rotation and a negavite represents a counter-clockwise
-/// rotation.
-#[derive(Debug, Clone, PartialEq)]
-pub struct TurnCmd(pub i32);
-
-/// Move specifies the steps that an agent will move in the direction it is
-/// facing.
-#[derive(Debug, Clone, PartialEq)]
-pub struct MoveCmd(pub u32);
-
-/// Goto jumps to the enclosed offset in an agents command list.
-#[derive(Debug, Clone, PartialEq)]
-pub struct GotoCmd(pub u32);
-
-/// Like Goto, JumpTrue jumps to the enclosed offset if the passed conditional
-/// expression evaluates to true.
-#[derive(Debug, Clone, PartialEq)]
-pub struct JumpTrueCmd(pub u32, pub Expression);
-
 /// Expresion covers the simple expression operations that can evaluated in
 /// some agent commands.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -88,6 +88,45 @@ pub enum Direction {
     NW,
 }
 
+impl Direction {
+    pub fn invert_x(self) -> Self {
+        match self {
+            Direction::NE => Direction::NW,
+            Direction::E => Direction::W,
+            Direction::SE => Direction::SW,
+            Direction::SW => Direction::SE,
+            Direction::W => Direction::E,
+            Direction::NW => Direction::NE,
+            other => other,
+        }
+    }
+
+    pub fn invert_y(self) -> Self {
+        match self {
+            Direction::NE => Direction::SE,
+            Direction::SE => Direction::NE,
+            Direction::SW => Direction::NW,
+            Direction::NW => Direction::SW,
+            Direction::N => Direction::S,
+            Direction::S => Direction::N,
+            other => other,
+        }
+    }
+
+    pub fn invert_xy(self) -> Self {
+        match self {
+            Direction::NE => Direction::SW,
+            Direction::SE => Direction::NW,
+            Direction::SW => Direction::NE,
+            Direction::NW => Direction::SE,
+            Direction::N => Direction::S,
+            Direction::S => Direction::N,
+            Direction::E => Direction::W,
+            Direction::W => Direction::E,
+        }
+    }
+}
+
 impl From<i32> for Direction {
     fn from(src: i32) -> Self {
         match (src % 8).abs() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,17 +156,17 @@ where
 /// Sets a variable identified by the string to the primitive evaluated to by
 /// the associated Expression on an associated agent..
 #[derive(Debug, Clone, PartialEq)]
-pub struct SetVariableCmd(pub String, pub Expression);
+pub(crate) struct SetVariableCmd(pub String, pub Expression);
 
 /// Defines the direction an agent should face.
 #[derive(Debug, Clone, PartialEq)]
-pub struct FaceCmd(pub ast::Direction);
+pub(crate) struct FaceCmd(pub ast::Direction);
 
 /// Turns by a number of rotations where a positive number represents a
 /// clockwise rotation and a negavite represents a counter-clockwise
 /// rotation.
 #[derive(Debug, Clone, PartialEq)]
-pub struct TurnCmd(pub i32);
+pub(crate) struct TurnCmd(pub i32);
 
 /// A marker trait used to flag traits that are used for implementing agent
 /// behavior when encountering a border boundary..
@@ -187,16 +187,16 @@ impl BoardBoundaryInteraction for WrapOnOverflow {}
 /// Move specifies the steps that an agent will move in the direction it is
 /// facing.
 #[derive(Debug, Clone, PartialEq)]
-pub struct MoveCmd<BI: BoardBoundaryInteraction>(pub BI, pub u32);
+pub(crate) struct MoveCmd<BI: BoardBoundaryInteraction>(pub BI, pub u32);
 
 /// Goto jumps to the enclosed offset in an agents command list.
 #[derive(Debug, Clone, PartialEq)]
-pub struct GotoCmd(pub u32);
+pub(crate) struct GotoCmd(pub u32);
 
 /// Like Goto, JumpTrue jumps to the enclosed offset if the passed conditional
 /// expression evaluates to true.
 #[derive(Debug, Clone, PartialEq)]
-pub struct JumpTrueCmd(pub u32, pub Expression);
+pub(crate) struct JumpTrueCmd(pub u32, pub Expression);
 
 impl EvaluateMut<ast::Command> for AgentState {
     type Output = Result<Vec<Coordinates>, String>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,6 +537,16 @@ pub fn tick_world(board: &mut Board) {
 pub const BOARD_WIDTH: u32 = 50;
 pub const BOARD_HEIGHT: u32 = 50;
 
+#[wasm_bindgen]
+pub fn board_width() -> u32 {
+    BOARD_WIDTH
+}
+
+#[wasm_bindgen]
+pub fn board_height() -> u32 {
+    BOARD_HEIGHT
+}
+
 lazy_static! {
     static ref BOARD: Mutex<Board> = Mutex::new(Board::new(BOARD_WIDTH, BOARD_HEIGHT));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ impl Coordinates {
     }
 }
 
+/// The runtime representation of a parsed agent.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AgentState {
     vars: HashMap<String, ast::Primitive>,
@@ -87,26 +88,36 @@ impl AgentState {
         }
     }
 
+    /// Sets the `commands` field, consuming and returning the agent-state
+    /// modified in place.
     pub fn with_commands(mut self, commands: Vec<ast::Command>) -> Self {
         self.commands = commands;
         self
     }
 
+    /// Sets the `pc` field, consuming and returning the agent-state modified
+    /// in place.
     pub fn with_pc(mut self, pc: u32) -> Self {
         self.pc = pc;
         self
     }
 
+    /// Sets the `directions` field, consuming and returning the agent-state
+    /// modified in place.
     pub fn with_direction(mut self, direction: ast::Direction) -> Self {
         self.direction = direction;
         self
     }
 
+    /// Sets the `color` field, consuming and returning the agent-state modified
+    /// in place.
     pub fn with_color(mut self, color: u32) -> Self {
         self.color = color;
         self
     }
 
+    /// Sets the `coordinates` field, consuming and returning the agent-state
+    /// modified in place.
     pub fn with_coordinates(mut self, coordinates: Coordinates) -> Self {
         self.coords = coordinates;
         self
@@ -123,6 +134,12 @@ impl Default for AgentState {
             direction: ast::Direction::S,
             color: Default::default(),
         }
+    }
+}
+
+impl From<ast::Agent> for AgentState {
+    fn from(agent: ast::Agent) -> Self {
+        AgentState::default().with_commands(agent.commands)
     }
 }
 
@@ -527,8 +544,10 @@ lazy_static! {
 #[wasm_bindgen]
 pub fn run(source: &str) {
     let program = parser::parse(source).unwrap();
-    for agent in <Vec<ast::Agent>>::from(program).into_iter() {
-        let new_state = AgentState::default().with_commands(agent.commands);
+    let agents: Vec<ast::Agent> = program.into();
+
+    for agent in agents.into_iter() {
+        let new_state = AgentState::from(agent);
         BOARD.lock().unwrap().agents.push(new_state);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,8 +324,8 @@ impl EvaluateMut<MoveCmd<ReflectOnOverflow>> for AgentState {
 
         let mut touched_cells = vec![];
 
-        let board_width = BOARD_WIDTH - 1;
-        let board_height = BOARD_HEIGHT - 1;
+        let board_width = BOARD_WIDTH;
+        let board_height = BOARD_HEIGHT;
 
         for _ in 0..steps {
             let Coordinates(x, y) = self.coords;
@@ -373,13 +373,15 @@ impl EvaluateMut<MoveCmd<ReflectOnOverflow>> for AgentState {
                 ast::Direction::NE => (x + 1, y - 1),
                 ast::Direction::NW => (x - 1, y - 1),
                 ast::Direction::E => (x + 1, y),
-                ast::Direction::SE => (x - 1, y + 1),
+                ast::Direction::SE => (x + 1, y + 1),
                 ast::Direction::S => (x, y + 1),
                 ast::Direction::SW => (x - 1, y + 1),
                 ast::Direction::W => (x - 1, y),
             };
 
-            touched_cells.push(Coordinates(offset_x as u32, offset_y as u32))
+            let new_coords = Coordinates(offset_x as u32, offset_y as u32);
+            touched_cells.push(new_coords);
+            self.coords = new_coords;
         }
 
         let end = touched_cells.last().copied().unwrap_or(self.coords);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,8 +324,8 @@ impl EvaluateMut<MoveCmd<ReflectOnOverflow>> for AgentState {
 
         let mut touched_cells = vec![];
 
-        let board_width = BOARD_WIDTH;
-        let board_height = BOARD_HEIGHT;
+        let board_width = BOARD_WIDTH - 1;
+        let board_height = BOARD_HEIGHT - 1;
 
         for _ in 0..steps {
             let Coordinates(x, y) = self.coords;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ impl BoardInteraction for WrapOnOverflow {}
 /// Move specifies the steps that an agent will move in the direction it is
 /// facing.
 #[derive(Debug, Clone, PartialEq)]
-pub struct MoveCmd<BI: BoardInteraction>(pub u32, pub BI);
+pub struct MoveCmd<BI: BoardInteraction>(pub BI, pub u32);
 
 /// Goto jumps to the enclosed offset in an agents command list.
 #[derive(Debug, Clone, PartialEq)]
@@ -183,7 +183,7 @@ impl EvaluateMut<ast::Command> for AgentState {
             ast::Command::SetVariable(id, expr) => self.evaluate_mut(SetVariableCmd(id, expr)),
             ast::Command::Face(dir) => self.evaluate_mut(FaceCmd(dir)),
             ast::Command::Turn(rotations) => self.evaluate_mut(TurnCmd(rotations)),
-            ast::Command::Move(steps) => self.evaluate_mut(MoveCmd(steps, WrapOnOverflow)),
+            ast::Command::Move(steps) => self.evaluate_mut(MoveCmd(WrapOnOverflow, steps)),
             ast::Command::Goto(command) => self.evaluate_mut(GotoCmd(command)),
             ast::Command::JumpTrue(next, expr) => self.evaluate_mut(JumpTrueCmd(next, expr)),
         }
@@ -254,7 +254,7 @@ impl EvaluateMut<MoveCmd<WrapOnOverflow>> for AgentState {
     type Output = Result<Vec<Coordinates>, String>;
 
     fn evaluate_mut(&mut self, operation: MoveCmd<WrapOnOverflow>) -> Self::Output {
-        let MoveCmd::<WrapOnOverflow>(steps, _) = operation;
+        let MoveCmd::<WrapOnOverflow>(_, steps) = operation;
         let orientation = self.direction;
         let origin = self.coords;
 
@@ -297,7 +297,7 @@ impl EvaluateMut<MoveCmd<ReflectOnOverflow>> for AgentState {
     type Output = Result<Vec<Coordinates>, String>;
 
     fn evaluate_mut(&mut self, operation: MoveCmd<ReflectOnOverflow>) -> Self::Output {
-        let MoveCmd::<ReflectOnOverflow>(steps, _) = operation;
+        let MoveCmd::<ReflectOnOverflow>(_, steps) = operation;
         let orientation = self.direction;
         let origin = self.coords;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,20 +151,26 @@ pub struct FaceCmd(pub ast::Direction);
 #[derive(Debug, Clone, PartialEq)]
 pub struct TurnCmd(pub i32);
 
-pub trait BoardInteraction {}
+/// A marker trait used to flag traits that are used for implementing agent
+/// behavior when encountering a border boundary..
+pub trait BoardBoundaryInteraction {}
 
+/// ReflectOnOverflow is a marker trait used to denote that agents should
+/// reflect when encountering a board boundary.
 pub struct ReflectOnOverflow;
 
-impl BoardInteraction for ReflectOnOverflow {}
+impl BoardBoundaryInteraction for ReflectOnOverflow {}
 
+/// WrapOnOverflow is a marker trait used to denote that agents should wrap
+/// when encountering a board boundary.
 pub struct WrapOnOverflow;
 
-impl BoardInteraction for WrapOnOverflow {}
+impl BoardBoundaryInteraction for WrapOnOverflow {}
 
 /// Move specifies the steps that an agent will move in the direction it is
 /// facing.
 #[derive(Debug, Clone, PartialEq)]
-pub struct MoveCmd<BI: BoardInteraction>(pub BI, pub u32);
+pub struct MoveCmd<BI: BoardBoundaryInteraction>(pub BI, pub u32);
 
 /// Goto jumps to the enclosed offset in an agents command list.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,62 +1,62 @@
 use crate::{AgentState, Evaluate};
 
+macro_rules! generate_move_command_assertion {
+    ($behavior:expr, $steps:literal => $x:literal, $y:literal) => {
+        assert_eq!(
+            AgentState::default()
+                .with_commands(vec![Command::Move($steps)])
+                .with_pc(1)
+                .with_coordinates(Coordinates($x, $y)),
+            MoveCmd($behavior, $steps)
+                .evaluate(AgentState::default().with_commands(vec![Command::Move($steps)]))
+        );
+    };
+    ($($behavior:expr, $steps:literal => $x:literal, $y:literal,)*) => {
+        $(
+        generate_move_command_assertion!($behavior, $steps=> $x, $y);
+        )*
+    };
+    ($behavior:expr, $steps:literal to $direction:expr => $x:literal, $y:literal) => {
+        assert_eq!(
+            AgentState::default()
+                .with_commands(vec![Command::Move($steps)])
+                .with_pc(1)
+                .with_coordinates(Coordinates($x, $y))
+                .with_direction($direction),
+            MoveCmd($behavior, $steps)
+                .evaluate(AgentState::default().with_direction($direction).with_commands(vec![Command::Move($steps)]))
+        );
+    };
+    ($($behavior:expr, $steps:literal to $direction:expr => $x:literal, $y:literal,)*) => {
+        $(
+        generate_move_command_assertion!($behavior, $steps to $direction => $x, $y);
+        )*
+    };
+}
+
 #[test]
-fn should_generate_expected_new_coordinates_for_move() {
+fn should_generate_expected_new_coordinates_for_move_when_wrapped() {
+    use crate::ast::{Command, Direction};
+    use crate::{Coordinates, MoveCmd, WrapOnOverflow};
+
+    generate_move_command_assertion!(
+        WrapOnOverflow, 5 => 0, 5,
+        WrapOnOverflow, 51 => 0, 1,
+    );
+
+    generate_move_command_assertion!(
+        WrapOnOverflow, 49 to Direction::N => 0, 1,
+        WrapOnOverflow, 49 to Direction::W => 1, 0,
+        WrapOnOverflow, 51 to Direction::E => 1, 0,
+    );
+}
+
+#[test]
+fn should_generate_expected_new_coordinates_for_move_when_reflected() {
     use crate::ast::Command;
-    use crate::Coordinates;
+    use crate::{Coordinates, MoveCmd, ReflectOnOverflow};
 
-    assert_eq!(
-        AgentState::default()
-            .with_commands(vec![Command::Move(5)])
-            .with_pc(1)
-            .with_coordinates(Coordinates(0, 5)),
-        Command::Move(5).evaluate(AgentState::default().with_commands(vec![Command::Move(5)]))
+    generate_move_command_assertion!(
+        ReflectOnOverflow, 5 => 0, 5,
     );
-
-    assert_eq!(
-        AgentState::default()
-            .with_commands(vec![Command::Move(51)])
-            .with_pc(1)
-            .with_coordinates(Coordinates(0, 1)),
-        Command::Move(51).evaluate(AgentState::default().with_commands(vec![Command::Move(51)]))
-    );
-
-    assert_eq!(
-        AgentState::default()
-            .with_commands(vec![Command::Move(49)])
-            .with_direction(crate::ast::Direction::N)
-            .with_pc(1)
-            .with_coordinates(Coordinates(0, 1)),
-        Command::Move(49).evaluate(
-            AgentState::default()
-                .with_direction(crate::ast::Direction::N)
-                .with_commands(vec![Command::Move(49)])
-        )
-    );
-
-    assert_eq!(
-        AgentState::default()
-            .with_commands(vec![Command::Move(49)])
-            .with_direction(crate::ast::Direction::W)
-            .with_pc(1)
-            .with_coordinates(Coordinates(1, 0)),
-        Command::Move(49).evaluate(
-            AgentState::default()
-                .with_direction(crate::ast::Direction::W)
-                .with_commands(vec![Command::Move(49)])
-        )
-    );
-
-    assert_eq!(
-        AgentState::default()
-            .with_commands(vec![Command::Move(51)])
-            .with_direction(crate::ast::Direction::E)
-            .with_pc(1)
-            .with_coordinates(Coordinates(1, 0)),
-        Command::Move(51).evaluate(
-            AgentState::default()
-                .with_direction(crate::ast::Direction::E)
-                .with_commands(vec![Command::Move(51)])
-        )
-    )
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -74,10 +74,10 @@ fn should_generate_expected_new_coordinates_for_move_when_reflected() {
 
     generate_move_command_assertion!(
         ReflectOnOverflow, 6 to Direction::N => 0, 6 with Direction::S,
-        ReflectOnOverflow, 51 to Direction::S => 0, 47 with Direction::N,
+        ReflectOnOverflow, 50 to Direction::S => 0, 48 with Direction::N,
         ReflectOnOverflow, 6 to Direction::W => 6, 0 with Direction::E,
-        ReflectOnOverflow, 51 to Direction::E => 47, 0 with Direction::W,
+        ReflectOnOverflow, 50 to Direction::E => 48, 0 with Direction::W,
         ReflectOnOverflow, 6 to Direction::NW => 6, 6 with Direction::SE,
-        ReflectOnOverflow, 51 to Direction::SE => 47, 47 with Direction::NW,
+        ReflectOnOverflow, 50 to Direction::SE => 48, 48 with Direction::NW,
     );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -74,10 +74,10 @@ fn should_generate_expected_new_coordinates_for_move_when_reflected() {
 
     generate_move_command_assertion!(
         ReflectOnOverflow, 6 to Direction::N => 0, 6 with Direction::S,
-        ReflectOnOverflow, 51 to Direction::S => 0, 49 with Direction::N,
+        ReflectOnOverflow, 51 to Direction::S => 0, 47 with Direction::N,
         ReflectOnOverflow, 6 to Direction::W => 6, 0 with Direction::E,
-        ReflectOnOverflow, 51 to Direction::E => 49, 0 with Direction::W,
+        ReflectOnOverflow, 51 to Direction::E => 47, 0 with Direction::W,
         ReflectOnOverflow, 6 to Direction::NW => 6, 6 with Direction::SE,
-        ReflectOnOverflow, 51 to Direction::SE => 49, 49 with Direction::NW,
+        ReflectOnOverflow, 51 to Direction::SE => 47, 47 with Direction::NW,
     );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -32,6 +32,22 @@ macro_rules! generate_move_command_assertion {
         generate_move_command_assertion!($behavior, $steps to $direction => $x, $y);
         )*
     };
+    ($behavior:expr, $steps:literal to $direction:expr => $x:literal, $y:literal with $new_direction:expr) => {
+        assert_eq!(
+            AgentState::default()
+                .with_commands(vec![Command::Move($steps)])
+                .with_pc(1)
+                .with_coordinates(Coordinates($x, $y))
+                .with_direction($new_direction),
+            MoveCmd($behavior, $steps)
+                .evaluate(AgentState::default().with_direction($direction).with_commands(vec![Command::Move($steps)]))
+        );
+    };
+    ($($behavior:expr, $steps:literal to $direction:expr => $x:literal, $y:literal with $new_direction:expr,)*) => {
+        $(
+        generate_move_command_assertion!($behavior, $steps to $direction => $x, $y with $new_direction);
+        )*
+    };
 }
 
 #[test]
@@ -53,10 +69,15 @@ fn should_generate_expected_new_coordinates_for_move_when_wrapped() {
 
 #[test]
 fn should_generate_expected_new_coordinates_for_move_when_reflected() {
-    use crate::ast::Command;
+    use crate::ast::{Command, Direction};
     use crate::{Coordinates, MoveCmd, ReflectOnOverflow};
 
     generate_move_command_assertion!(
-        ReflectOnOverflow, 5 => 0, 5,
+        ReflectOnOverflow, 6 to Direction::N => 0, 6 with Direction::S,
+        ReflectOnOverflow, 51 to Direction::S => 0, 49 with Direction::N,
+        ReflectOnOverflow, 6 to Direction::W => 6, 0 with Direction::E,
+        ReflectOnOverflow, 51 to Direction::E => 49, 0 with Direction::W,
+        ReflectOnOverflow, 6 to Direction::NW => 6, 6 with Direction::SE,
+        ReflectOnOverflow, 51 to Direction::SE => 49, 49 with Direction::NW,
     );
 }

--- a/www/index.js
+++ b/www/index.js
@@ -69,7 +69,7 @@ document.getElementById('runcode').addEventListener('click', () => {
 loop();
 
 document.getElementById('editor').innerHTML = `agent red_agent:
-    set color = 255
+    set color = 16711680
     set x = 20
     set y = 20
     set a = 0

--- a/www/index.js
+++ b/www/index.js
@@ -4,8 +4,8 @@ const CELL_SIZE = 12;
 const GRID_COLOR = "#CCCCCC";
 
 // Construct the universe, and get its width and height.
-const width = 50;
-const height = 50;
+const width = wasm.board_width();
+const height = wasm.board_height();
 
 const RED_MASK = 0xff << 16;
 const GREEN_MASK = 0xff << 8;
@@ -42,9 +42,9 @@ function drawGrid() {
   ctx.stroke();
 
   let colors = wasm.tick();
-  for (let y = 0; y < 50; y++) {
-    for (let x = 0; x < 50; x++) {
-      let i = y * 50 + x;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let i = y * height + x;
       let color = colors[i];
       ctx.fillStyle = 'rgb(' + (color & RED_MASK).toString() + ',' + (color & GREEN_MASK).toString() + ',' + (color & BLUE_MASK).toString() + ')';
       ctx.fillRect((CELL_SIZE + 1) * x + 2, (CELL_SIZE + 1) * y + 2, CELL_SIZE - 1, CELL_SIZE - 1);
@@ -72,15 +72,11 @@ document.getElementById('editor').innerHTML = `agent red_agent:
     set color = 16711680
     set x = 20
     set y = 20
-    set a = 0
     loop:
         face NW
         move 1
         turn -4
         goto loop
-        set a = 5
-        jump to exit if a is 1
-    exit:
 agent blue_agent:
     set color = 255
     set x = 20
@@ -90,8 +86,6 @@ agent blue_agent:
         move 2
         turn -30
         goto loop
-        set b = 5
-    exit:
 `
 
 let editor = ace.edit('editor');


### PR DESCRIPTION
# Introduction
This PR introduces board boundary interactions allowing for wrapping and reflecting behavior.

## Examples
### Wrapping behavior
![Wrapping behavior](https://user-images.githubusercontent.com/6344112/144906495-04de1635-d239-45db-a51f-80080488607a.png)

### Reflecting Behavior
![Reflecting behavior](https://user-images.githubusercontent.com/6344112/144906500-6bb28949-c600-4cc5-980a-15ed9348d86f.png)

## Additional Changes

- Moves the runtime command times from the `ast` module to `lib` with the other runtime types
- Parameterizes this behavior which can be set in the `tick_agent` function with a type parameter
- Exposes board dimension statics to JS through a function
- Adds a significant amount of movement tests
- Simplifies the example scripts

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
