### PR TITLE
Increase pixel density and reflect by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,7 +569,7 @@ pub fn tick_agent(agent_state: &mut AgentState) -> Vec<Coordinates> {
         .cloned()
         .unwrap();
 
-    EvaluateMut::<WrapOnOverflow, _>::evaluate_mut(agent_state, command).unwrap()
+    EvaluateMut::<ReflectOnOverflow, _>::evaluate_mut(agent_state, command).unwrap()
 }
 
 pub fn tick_world(board: &mut Board) {
@@ -586,8 +586,8 @@ pub fn tick_world(board: &mut Board) {
     }
 }
 
-pub const BOARD_WIDTH: u32 = 50;
-pub const BOARD_HEIGHT: u32 = 50;
+pub const BOARD_WIDTH: u32 = 100;
+pub const BOARD_HEIGHT: u32 = 100;
 
 #[wasm_bindgen]
 pub fn board_width() -> u32 {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -57,13 +57,13 @@ fn should_generate_expected_new_coordinates_for_move_when_wrapped() {
 
     generate_move_command_assertion!(
         WrapOnOverflow, 5 => 0, 5,
-        WrapOnOverflow, 51 => 0, 1,
+        WrapOnOverflow, 101 => 0, 1,
     );
 
     generate_move_command_assertion!(
-        WrapOnOverflow, 49 to Direction::N => 0, 1,
-        WrapOnOverflow, 49 to Direction::W => 1, 0,
-        WrapOnOverflow, 51 to Direction::E => 1, 0,
+        WrapOnOverflow, 49 to Direction::N => 0, 51,
+        WrapOnOverflow, 49 to Direction::W => 51, 0,
+        WrapOnOverflow, 101 to Direction::E => 1, 0,
     );
 }
 
@@ -74,10 +74,10 @@ fn should_generate_expected_new_coordinates_for_move_when_reflected() {
 
     generate_move_command_assertion!(
         ReflectOnOverflow, 6 to Direction::N => 0, 6 with Direction::S,
-        ReflectOnOverflow, 50 to Direction::S => 0, 48 with Direction::N,
+        ReflectOnOverflow, 100 to Direction::S => 0, 98 with Direction::N,
         ReflectOnOverflow, 6 to Direction::W => 6, 0 with Direction::E,
-        ReflectOnOverflow, 50 to Direction::E => 48, 0 with Direction::W,
+        ReflectOnOverflow, 100 to Direction::E => 98, 0 with Direction::W,
         ReflectOnOverflow, 6 to Direction::NW => 6, 6 with Direction::SE,
-        ReflectOnOverflow, 50 to Direction::SE => 48, 48 with Direction::NW,
+        ReflectOnOverflow, 100 to Direction::SE => 98, 98 with Direction::NW,
     );
 }

--- a/www/index.js
+++ b/www/index.js
@@ -1,6 +1,6 @@
 import * as wasm from 'agents';
 
-const CELL_SIZE = 12;
+const CELL_SIZE = 5;
 const GRID_COLOR = "#CCCCCC";
 
 // Construct the universe, and get its width and height.
@@ -52,7 +52,7 @@ function drawGrid() {
   }
 }
 
-let fps = 2;
+let fps = 10;
 
 function loop() {
   drawGrid();
@@ -70,21 +70,19 @@ loop();
 
 document.getElementById('editor').innerHTML = `agent red_agent:
     set color = 16711680
-    set x = 20
-    set y = 20
+    set x = 40
+    set y = 40
+    face NW
     loop:
-        face NW
         move 1
-        turn -4
         goto loop
 agent blue_agent:
     set color = 255
-    set x = 20
-    set y = 20
+    set x = 40
+    set y = 40
+    face NE
     loop:
-        face NE
         move 2
-        turn -30
         goto loop
 `
 


### PR DESCRIPTION
# Introduction
This PR doubles the pixel count and shrinks the pixel size from 12 -> 5. This also sets ReflectOnOverflow as the default boundary behavior.

# Linked Issues
resolve #17 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
