### PR TITLE
Fix failing increment in set instructions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -21,7 +21,7 @@ impl From<Program> for Vec<Agent> {
 }
 
 /// An agent is represented by a list of commands.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Agent {
     pub commands: Vec<Command>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,13 @@ impl AgentState {
         self.coords = coordinates;
         self
     }
+
+    /// Adds a variable mapping, consuming and returning the agent-state
+    /// modified in place.
+    pub fn with_variable(mut self, key: &str, value: ast::Primitive) -> Self {
+        self.vars.insert(key.to_string(), value);
+        self
+    }
 }
 
 impl Default for AgentState {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,10 @@ impl<BBI: BoardBoundaryInteraction> EvaluateMut<BBI, JumpTrueCmd> for AgentState
 
         match prim {
             pi @ Primitive::Integer(_) => Err(format!("condition is non-boolean: {:?}", &pi)),
-            Primitive::Boolean(false) => todo!(),
+            Primitive::Boolean(false) => {
+                self.pc += 1;
+                Ok(vec![])
+            }
             Primitive::Boolean(true) => {
                 self.pc = next;
                 Ok(vec![])
@@ -568,15 +571,14 @@ impl Board {
 }
 
 pub fn tick_agent(agent_state: &mut AgentState) -> Vec<Coordinates> {
-    // TODO: implement interpreter here
-    // TODO: change pc here
-    let command = agent_state
+    agent_state
         .commands
         .get(agent_state.pc as usize)
         .cloned()
-        .unwrap();
-
-    EvaluateMut::<ReflectOnOverflow, _>::evaluate_mut(agent_state, command).unwrap()
+        .and_then(|command| {
+            EvaluateMut::<ReflectOnOverflow, _>::evaluate_mut(agent_state, command).ok()
+        })
+        .unwrap_or_else(Vec::new)
 }
 
 pub fn tick_world(board: &mut Board) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -157,7 +157,7 @@ fn set_command<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ParsedComma
         parcel::join(
             identifier(),
             parcel::right(parcel::join(
-                whitespace_wrapped(expect_character('=')),
+                non_newline_whitespace_wrapped(expect_character('=')),
                 expression(),
             )),
         ),
@@ -171,11 +171,11 @@ fn jump_true_command<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Parse
         parcel::join(
             identifier(),
             parcel::right(parcel::join(
-                whitespace_wrapped(expect_str("if")),
+                non_newline_whitespace_wrapped(expect_str("if")),
                 parcel::join(
                     expression(),
                     parcel::right(parcel::join(
-                        whitespace_wrapped(expect_str("is")),
+                        non_newline_whitespace_wrapped(expect_str("is")),
                         expression(),
                     )),
                 ),
@@ -400,17 +400,6 @@ fn boolean<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], bool> {
     expect_str("true")
         .map(|_| true)
         .or(|| expect_str("false").map(|_| false))
-}
-
-fn whitespace_wrapped<'a, P, B>(parser: P) -> impl Parser<'a, &'a [(usize, char)], B>
-where
-    B: 'a,
-    P: Parser<'a, &'a [(usize, char)], B> + 'a,
-{
-    parcel::right(parcel::join(
-        parcel::zero_or_more(whitespace()),
-        parcel::left(parcel::join(parser, parcel::zero_or_more(whitespace()))),
-    ))
 }
 
 fn non_newline_whitespace_wrapped<'a, P, B>(parser: P) -> impl Parser<'a, &'a [(usize, char)], B>

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -95,7 +95,7 @@ fn should_allow_expressions_in_assignment() {
         AgentState::default()
             .with_commands(vec![cmd.clone()])
             .with_pc(1)
-            .with_variable("test", Primitive::Integer(5)),
+            .with_variable(var_name, Primitive::Integer(5)),
         Evaluate::<crate::WrapOnOverflow, _>::evaluate(
             SetVariableCmd(var_name.to_string(), literal_expr),
             AgentState::default().with_commands(vec![cmd]),
@@ -112,7 +112,7 @@ fn should_allow_expressions_in_assignment() {
         AgentState::default()
             .with_commands(vec![cmd.clone()])
             .with_pc(1)
-            .with_variable("test", Primitive::Integer(9)),
+            .with_variable(var_name, Primitive::Integer(9)),
         Evaluate::<crate::WrapOnOverflow, _>::evaluate(
             SetVariableCmd(var_name.to_string(), arithmetic_expr,),
             AgentState::default().with_commands(vec![cmd]),
@@ -130,12 +130,39 @@ fn should_allow_expressions_in_assignment() {
         AgentState::default()
             .with_commands(vec![cmd.clone()])
             .with_pc(1)
-            .with_variable("test", Primitive::Integer(9)),
+            .with_variable(var_name, Primitive::Integer(9)),
         Evaluate::<crate::WrapOnOverflow, _>::evaluate(
             SetVariableCmd(var_name.to_string(), assignment_expr,),
             AgentState::default()
                 .with_commands(vec![cmd])
-                .with_variable("test", Primitive::Integer(4)),
+                .with_variable(var_name, Primitive::Integer(4)),
+        )
+    )
+}
+
+#[test]
+fn should_jump_expressions_in_assignment() {
+    use crate::ast::{Command, Expression, Primitive};
+
+    let var_name = "test";
+
+    let cmd = Command::JumpTrue(
+        5,
+        Expression::Equals(
+            Box::new(Expression::GetVariable(var_name.to_string())),
+            Box::new(Expression::Literal(Primitive::Integer(1))),
+        ),
+    );
+    assert_eq!(
+        AgentState::default()
+            .with_commands(vec![cmd.clone()])
+            .with_pc(5)
+            .with_variable("test", Primitive::Integer(1)),
+        Evaluate::<crate::WrapOnOverflow, _>::evaluate(
+            cmd.clone(),
+            AgentState::default()
+                .with_commands(vec![cmd])
+                .with_variable("test", Primitive::Integer(1)),
         )
     )
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -81,3 +81,61 @@ fn should_generate_expected_new_coordinates_for_move_when_reflected() {
         ReflectOnOverflow, 100 to Direction::SE => 98, 98 with Direction::NW,
     );
 }
+
+#[test]
+fn should_allow_expressions_in_assignment() {
+    use crate::ast::{Command, Expression, Primitive};
+    use crate::SetVariableCmd;
+
+    // literals
+    let var_name = "test";
+    let literal_expr = Expression::Literal(Primitive::Integer(5));
+    let cmd = Command::SetVariable(var_name.to_string(), literal_expr.clone());
+    assert_eq!(
+        AgentState::default()
+            .with_commands(vec![cmd.clone()])
+            .with_pc(1)
+            .with_variable("test", Primitive::Integer(5)),
+        Evaluate::<crate::WrapOnOverflow, _>::evaluate(
+            SetVariableCmd(var_name.to_string(), literal_expr),
+            AgentState::default().with_commands(vec![cmd]),
+        )
+    );
+
+    // arithmetic expressions
+    let arithmetic_expr = Expression::Add(
+        Box::new(Expression::Literal(Primitive::Integer(5))),
+        Box::new(Expression::Literal(Primitive::Integer(4))),
+    );
+    let cmd = Command::SetVariable(var_name.to_string(), arithmetic_expr.clone());
+    assert_eq!(
+        AgentState::default()
+            .with_commands(vec![cmd.clone()])
+            .with_pc(1)
+            .with_variable("test", Primitive::Integer(9)),
+        Evaluate::<crate::WrapOnOverflow, _>::evaluate(
+            SetVariableCmd(var_name.to_string(), arithmetic_expr,),
+            AgentState::default().with_commands(vec![cmd]),
+        )
+    );
+
+    // assignment expressions
+    let assignment_expr = Expression::Add(
+        Box::new(Expression::GetVariable(var_name.to_string())),
+        Box::new(Expression::Literal(Primitive::Integer(5))),
+    );
+
+    let cmd = Command::SetVariable(var_name.to_string(), assignment_expr.clone());
+    assert_eq!(
+        AgentState::default()
+            .with_commands(vec![cmd.clone()])
+            .with_pc(1)
+            .with_variable("test", Primitive::Integer(9)),
+        Evaluate::<crate::WrapOnOverflow, _>::evaluate(
+            SetVariableCmd(var_name.to_string(), assignment_expr,),
+            AgentState::default()
+                .with_commands(vec![cmd])
+                .with_variable("test", Primitive::Integer(4)),
+        )
+    )
+}

--- a/www/index.js
+++ b/www/index.js
@@ -72,9 +72,16 @@ document.getElementById('editor').innerHTML = `agent red_agent:
     set color = 16711680
     set x = 40
     set y = 40
+    set acc = 1
     face NW
     loop:
         move 1
+        jump to spin if acc is 4
+        set acc = acc + 1
+        goto loop
+    spin:
+        turn 1
+        set acc = 1
         goto loop
 agent blue_agent:
     set color = 255


### PR DESCRIPTION
# Introduction
This PR fixes expression evaluation in set instructions due to newlines being eaten by the expression parser. This also fixes a missing boolean false branch in the jmp cmd.
# Linked Issues
resolves #14 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
