### PR TITLE
Implement comment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,33 +3,59 @@
 ## Examples
 
 ```
+# A program is composed of one or more independent agents.
+# Agents move around the board in the direction they are oriented in on cycle
+# of ticks, leaving behind a colored wake in their path.
+#
+# Agents are defined by by using the "agent" keyword followed by a name and
+# semicolon.
 agent red_agent:
+    # Everything in a agent block is a statement.
+    #
+    # Statements can be labels, variables or commands.
+    # 
+    # Some variables are special and impact the board.
+    # These include color, x and y for cell color or coordinates.
     set color = 16711680
-    set x = 0
-    set y = 0
-    set direction = 0
-    set a = 0
+    set x = 40
+    set y = 40
+    # Other variables can be general purpose.
+    set acc = 1
+    # Commands control either agent behavior or control flow.
+    #
+    # face changes orientation of an agent and takes a cardinal direction, like
+    # S, E or NW.
+    face NW
+    # Labels allow defining locations in code for a program to jump to
     loop:
-        face NW
-        move 10
-        turn -4
+        # Move takes a positive 32 bit integer and controls the number of steps
+        # to move in a tick in this case our agent will move one space per tick
+        # in the direction they are facing.
+        move 1
+        # Agent scripts support branching through the "jump to" command.
+        # These commands look like:
+        # "jump to <label> if <expression> is <expresion>".
+        jump to spin if acc is 4
+        # Variables also support basic arithmetic expressions.
+        set acc = acc + 1
+        # The goto command allows for the basic jumping to a label without a
+        # condition.
         goto loop
-        set a = 5
-        jump to exit if a is 1
-    exit:
+    spin:
+        # The turn command allows spinning an agent based on their current 
+        # orientation. With a positive number being a clockwise rotation and a
+        # negative being counter-clockwise.
+        turn 1
+        set acc = 1
+        goto loop
 agent blue_agent:
     set color = 255
-    set x = 0
-    set y = 0
-    set direction = 0
-    set a = 0
+    set x = 40
+    set y = 40
+    face NE
     loop:
-        face NE
-        move 20
-        turn -30
+        move 2
         goto loop
-        set b = 5
-    exit:
 ```
 
 ## Referenced Links and Credits

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 agent red_agent:
     # Everything in a agent block is a statement.
     #
-    # Statements can be labels, variables or commands.
+    # Statements can be labels or commands.
     # 
-    # Some variables are special and impact the board.
+    # One such command is "set", used for defining variables.
+    # Some variables are special and impact an agents placement or effect on
+    # the board.
     # These include color, x and y for cell color or coordinates.
     set color = 16711680
     set x = 40

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -159,7 +159,7 @@ fn comment<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ()> {
     parcel::right(parcel::join(
         expect_character('#'),
         parcel::left(parcel::join(
-            parcel::one_or_more(any_non_whitespace_character().or(non_newline_whitespace))
+            parcel::zero_or_more(any_non_whitespace_character().or(non_newline_whitespace))
                 .map(|_| ()),
             newline_terminated_whitespace(),
         )),
@@ -532,7 +532,9 @@ agent blue_agent:
             Expression,
         };
         let set_inst = "# top-level comment
+# hello
 agent red_agent:
+    #
     # statement-level comment
     set a = 4 # inline comment
 ";

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,8 +4,9 @@ use parcel::prelude::v1::*;
 use crate::ast;
 
 #[derive(Debug)]
-enum CommandOrLabel {
+enum Statements {
     Label(String),
+    Comment,
     Command(ParsedCommand),
 }
 
@@ -51,7 +52,7 @@ fn agent<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Agent> {
     move |input: &'a [(usize, char)]| {
         let (span, remainder, command_or_labels) = parcel::right(parcel::join(
             expect_str("agent "),
-            parcel::join(label(), parcel::zero_or_more(command_or_label())),
+            parcel::join(label(), parcel::zero_or_more(statement())),
         ))
         .parse(input)
         .map_err(ParseErr::Unspecified)
@@ -72,11 +73,12 @@ fn agent<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Agent> {
             .fold(
                 (HashMap::new(), 0usize),
                 |(mut labels, idx), col| match col {
-                    CommandOrLabel::Label(id) => {
+                    Statements::Label(id) => {
                         labels.insert(id.clone(), idx);
                         (labels, idx)
                     }
-                    CommandOrLabel::Command(_) => (labels, idx + 1),
+                    Statements::Command(_) => (labels, idx + 1),
+                    Statements::Comment => (labels, idx),
                 },
             )
             // Index isn't needeed after calculating the labels.
@@ -85,8 +87,8 @@ fn agent<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Agent> {
         command_or_labels
             .into_iter()
             .map(|col| match col {
-                CommandOrLabel::Label(_) => None,
-                CommandOrLabel::Command(pc) => Some(pc),
+                Statements::Label(_) | Statements::Comment => None,
+                Statements::Command(pc) => Some(pc),
             })
             .flatten()
             .map(|pc| match pc {
@@ -119,12 +121,13 @@ fn agent<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Agent> {
     }
 }
 
-fn command_or_label<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], CommandOrLabel> {
+fn statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Statements> {
     parcel::right(parcel::join(
         parcel::one_or_more(non_newline_whitespace()),
         command()
-            .map(CommandOrLabel::Command)
-            .or(|| label().map(CommandOrLabel::Label)),
+            .map(Statements::Command)
+            .or(|| comment().map(|_| Statements::Comment))
+            .or(|| label().map(Statements::Label)),
     ))
 }
 
@@ -132,6 +135,17 @@ fn label<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], String> {
     parcel::left(parcel::join(
         identifier(),
         parcel::join(expect_character(':'), newline_terminated_whitespace()),
+    ))
+}
+
+fn comment<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ()> {
+    parcel::right(parcel::join(
+        expect_character('#'),
+        parcel::left(parcel::join(
+            parcel::one_or_more(any_non_whitespace_character().or(non_newline_whitespace))
+                .map(|_| ()),
+            newline_terminated_whitespace(),
+        )),
     ))
 }
 
@@ -480,6 +494,33 @@ agent blue_agent:
                 ),
             ),
         ];
+
+        assert_eq!(
+            Ok(Agent::new(expected_cmds)),
+            res.and_then(|program| program
+                .agents()
+                .get(0)
+                .cloned()
+                .ok_or_else(|| { ParseErr::Unspecified("no agents parsed".to_string()) })),
+        );
+    }
+
+    #[test]
+    fn should_parse_comments() {
+        use crate::{
+            ast::{Agent, Command, Primitive},
+            parser::ParseErr,
+            Expression,
+        };
+        let set_inst = "agent red_agent:
+    # test
+    set a = 4
+";
+        let res = crate::parser::parse(set_inst);
+        let expected_cmds = vec![Command::SetVariable(
+            "a".to_string(),
+            Expression::Literal(Primitive::Integer(4)),
+        )];
 
         assert_eq!(
             Ok(Agent::new(expected_cmds)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -161,7 +161,9 @@ fn command<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ParsedCommand> 
             .or(turn_command)
             .or(goto_command)
             .or(jump_true_command),
-        newline_terminated_whitespace(),
+        parcel::join(parcel::one_or_more(non_newline_whitespace()), comment())
+            .map(|_| '\n')
+            .or(newline_terminated_whitespace),
     ))
 }
 
@@ -514,7 +516,7 @@ agent blue_agent:
         };
         let set_inst = "agent red_agent:
     # test
-    set a = 4
+    set a = 4 # test
 ";
         let res = crate::parser::parse(set_inst);
         let expected_cmds = vec![Command::SetVariable(

--- a/www/index.js
+++ b/www/index.js
@@ -77,9 +77,11 @@ document.getElementById('editor').innerHTML = `# A program is composed of one or
 agent red_agent:
     # Everything in a agent block is a statement.
     #
-    # Statements can be labels, variables or commands.
+    # Statements can be labels or commands.
     # 
-    # Some variables are special and impact the board.
+    # One such command is "set", used for defining variables.
+    # Some variables are special and impact an agents placement or effect on
+    # the board.
     # These include color, x and y for cell color or coordinates.
     set color = 16711680
     set x = 40

--- a/www/index.js
+++ b/www/index.js
@@ -68,18 +68,45 @@ document.getElementById('runcode').addEventListener('click', () => {
 
 loop();
 
-document.getElementById('editor').innerHTML = `agent red_agent:
+document.getElementById('editor').innerHTML = `# A program is composed of one or more independent agents.
+# Agents are defined by by using the "agent" keyword followed by a name and
+# semicolon.
+agent red_agent:
+    # Everything in a agent block is a statement.
+    #
+    # Statements can be labels, variables or commands.
+    # 
+    # Some variables are special and impact the board.
+    # These include color, x and y for cell color or coordinates.
     set color = 16711680
     set x = 40
     set y = 40
+    # Other variables can be general purpose.
     set acc = 1
+    # Commands control either agent behavior or control flow.
+    #
+    # face changes orientation of an agent and takes a cardinal direction, like
+    # S, E or NW.
     face NW
+    # Labels allow defining locations in code for a program to jump to
     loop:
+        # Move takes a positive 32 bit integer and controls the number of steps
+        # to move in a tick in this case our agent will move one space per tick
+        # in the direction they are facing.
         move 1
+        # Agent scripts support branching through the "jump to" command.
+        # These commands look like:
+        # "jump to <label> if <expression> is <expresion>".
         jump to spin if acc is 4
+        # Variables also support basic arithmetic expressions.
         set acc = acc + 1
+        # The goto command allows for the basic jumping to a label without a
+        # condition.
         goto loop
     spin:
+        # The turn command allows spinning an agent based on their current 
+        # orientation. With a positive number being a clockwise rotation and a
+        # negative being counter-clockwise.
         turn 1
         set acc = 1
         goto loop

--- a/www/index.js
+++ b/www/index.js
@@ -69,6 +69,9 @@ document.getElementById('runcode').addEventListener('click', () => {
 loop();
 
 document.getElementById('editor').innerHTML = `# A program is composed of one or more independent agents.
+# Agents move around the board in the direction they are oriented in on cycle
+# of ticks, leaving behind a colored wake in their path.
+#
 # Agents are defined by by using the "agent" keyword followed by a name and
 # semicolon.
 agent red_agent:


### PR DESCRIPTION
# Introduction
This PR implements comment syntax in the language allowing comments inline or on a line of their own.

Additionally this adds comments to the example program for clarity.

```
# top-level comment
# hello
agent red_agent:
    #
    # statement-level comment
    set a = 4 # inline comment
```
# Linked Issues
resolves #20 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
