### PR TITLE
Bump parcel to v2.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ opt-level = "s"
 wasm-opt = false
 
 [dependencies]
-parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.0" }
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.1" }
 wasm-bindgen = "0.2"
 lazy_static = "1.4.0"


### PR DESCRIPTION
# Introduction
Small dependency version bump to include the `v2.0.1` fixes for parcel. Mostly this is to add spanning fixes in the parser for future error handling.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
